### PR TITLE
修改文档中，zsh 长效解决 gf 命令冲突方案

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -20,7 +20,7 @@ After downloads, please use `gf install` command to install gf binary to system 
     ```shell
     wget https://goframe.org/cli/darwin_amd64/gf && chmod +x gf && ./gf install
     ```
-   > If you're using `zsh`, you might need rename your alias by command `alias gf=gf` to resolve the conflicts between `gf` and `git fetch`.
+   > If you're using `zsh`, you might need rename your alias by command `alias gf=gf` to resolve the conflicts between `gf` and `git fetch`. Or use this command `echo alias gf=gf>>~/.zshrc && source ~/.zshrc` to achieve long-term results.
 1. `Windows`
 
     Manually download and move it to `C:\Windows` folder, and then you can enjoy it in `cmd`.

--- a/commands/install/install.go
+++ b/commands/install/install.go
@@ -16,6 +16,15 @@ func Run() {
 	} else {
 		mlog.Printf("gf binary is successfully installed to: %s", path)
 	}
+	if IsInstalled() {
+		shell := CurrentShell()
+		if shell == "zsh" {
+			err := AliasZSHConf("gf", "gf")
+			if err != nil {
+				mlog.Print("your shell is zsh, you might need rename your alias by command `echo alias gf=gf>>~/.zshrc && source ~/.zshrc` to resolve the conflicts between `gf` and `git fetch`")
+			}
+		}
+	}
 }
 
 // IsInstalled returns whether the binary installed.
@@ -35,4 +44,36 @@ func GetInstallFolderPath() string {
 // getInstallBinaryPath returns the installation path for the binary.
 func GetInstallBinaryPath() string {
 	return gfile.Join(GetInstallFolderPath(), "gf"+gfile.Ext(gfile.SelfPath()))
+}
+
+// currentShell returns current shell name
+func CurrentShell() string {
+	if runtime.GOOS != "windows" {
+		osPid := gproc.PPidOS()
+		psCmd := fmt.Sprintf("ps -p %d -ocomm=", osPid)
+		ps, err := gproc.ShellExec(psCmd)
+		if err != nil {
+			return ""
+		}
+		return gstr.Trim(ps)
+	}
+	return ""
+}
+
+// aliasZSHConf append `alias command=dstCommand` to .zshrc if this file exist
+func AliasZSHConf(command, dstCommand string) error {
+	homePath, err := gfile.Home()
+	if err != nil {
+		return err
+	}
+	confPath := fmt.Sprintf("%s/.zshrc", homePath)
+	if gfile.Exists(confPath) {
+		content := gfile.GetContents(confPath)
+		if !gstr.ContainsI(content, "alias gf=gf") {
+			if err := gfile.PutContentsAppend(confPath, fmt.Sprintf("alias %s=%s", command, dstCommand)); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
以我的水准实现检测alias列表略有难度，检测.zshrc文件倒是不难，但实现不太优雅，而且即使实现了感觉侵入性也比较强，最后只好靠提交文档来给一个相对方便的解决方案。