### PR TITLE
fix: error occurs when github.com/swaggo/swag/cmd/swag was not installed

### DIFF
--- a/commands/swagger/swagger.go
+++ b/commands/swagger/swagger.go
@@ -18,7 +18,7 @@ import (
 
 const (
 	defaultOutput  = "./swagger"
-	swaggoRepoPath = "go get -u github.com/swaggo/swag/cmd/swag"
+	swaggoRepoPath = "github.com/swaggo/swag/cmd/swag"
 )
 
 var (


### PR DESCRIPTION
`commands/swagger/swagger.go:120-125`