### PR TITLE
gf gen 兼容 gorm 的模式定义，以期基本实现 gorm 的自动迁移 #779

### DIFF
--- a/commands/gen/gen_model.go
+++ b/commands/gen/gen_model.go
@@ -106,12 +106,12 @@ func generateModelContentFile(db gdb.DB, table, variable, folderPath, groupName 
 	camelName := gstr.CamelCase(variable)
 	structDefine := generateStructDefinition(fieldMap)
 	packageImports := ""
-	if strings.Contains(structDefine, "gtime.Time") {
+	if strings.Contains(structDefine, "time.Time") {
 		packageImports = gstr.Trim(`
 import (
 	"database/sql"
 	"github.com/gogf/gf/database/gdb"
-	"github.com/gogf/gf/os/gtime"
+	"time"
 )`)
 	} else {
 		packageImports = gstr.Trim(`
@@ -233,7 +233,7 @@ func generateStructField(field *gdb.TableField) []string {
 		typeName = "bool"
 
 	case "datetime", "timestamp", "date", "time":
-		typeName = "*gtime.Time"
+		typeName = "time.Time"
 
 	default:
 		// Auto detecting type.
@@ -249,7 +249,7 @@ func generateStructField(field *gdb.TableField) []string {
 		case strings.Contains(t, "binary") || strings.Contains(t, "blob"):
 			typeName = "[]byte"
 		case strings.Contains(t, "date") || strings.Contains(t, "time"):
-			typeName = "*gtime.Time"
+			typeName = "time.Time"
 		default:
 			typeName = "string"
 		}

--- a/commands/gen/gen_model_template_entity.go
+++ b/commands/gen/gen_model_template_entity.go
@@ -12,6 +12,11 @@ package {TplPackageName}
 // Entity is the golang structure for table {TplTableName}.
 {TplStructDefine}
 
+// Get table name of entity
+func (r *Entity) TableName() string {
+	return "{TplTableName}"
+}
+
 // OmitEmpty sets OPTION_OMITEMPTY option for the model, which automatically filers
 // the data and where attributes for empty values.
 func (r *Entity) OmitEmpty() *arModel {


### PR DESCRIPTION
1，增加了一个 TableName 方法，实现 gorm 的表名接口
2，因为 gtime的时间不兼容，所以将 gtime 改回原始的 time 类型，目前测试运行良好