### PR TITLE
trim ulimit string

### DIFF
--- a/commands/run/run.go
+++ b/commands/run/run.go
@@ -182,7 +182,7 @@ func (app *App) Run() {
 	// In case of `pipe: too many open files` error.
 	ulimitCommand := ""
 	if gproc.SearchBinary("ulimit") != "" {
-		if r, _ := gproc.ShellExec("ulimit -n"); gconv.Int(r) < 65535 {
+		if r, _ := gproc.ShellExec("ulimit -n"); gconv.Int(strings.Trim(r, "\n")) < 65535 {
 			ulimitCommand = `ulimit -n 65535 && `
 		}
 	}


### PR DESCRIPTION
gproc.ShellExec("ulimit -n") mac 下 获取字符串为  1024\n  gconv.Int 转换始终为 0