### PR TITLE
fix gen dao/model: pgsql int8 to local int64

### DIFF
--- a/commands/gen/gen_dao.go
+++ b/commands/gen/gen_dao.go
@@ -281,7 +281,7 @@ func generateStructFieldForDao(field *gdb.TableField) []string {
 			typeName = "int"
 		}
 
-	case "big_int", "bigint":
+	case "big_int", "bigint", "int8":
 		if gstr.ContainsI(field.Type, "unsigned") {
 			typeName = "uint64"
 		} else {

--- a/commands/gen/gen_model.go
+++ b/commands/gen/gen_model.go
@@ -216,7 +216,7 @@ func generateStructField(field *gdb.TableField) []string {
 			typeName = "int"
 		}
 
-	case "big_int", "bigint":
+	case "big_int", "bigint", "int8":
 		if gstr.ContainsI(field.Type, "unsigned") {
 			typeName = "uint64"
 		} else {


### PR DESCRIPTION
pgsql int8字段，生成model类型应为int64