### PR TITLE
让 build 命令可以显示 error 信息

### DIFF
--- a/command/build/build.go
+++ b/command/build/build.go
@@ -3,6 +3,10 @@ package build
 import (
 	"encoding/json"
 	"fmt"
+	"regexp"
+	"runtime"
+	"strings"
+
 	"github.com/gogf/gf-cli/library/mlog"
 	"github.com/gogf/gf/encoding/gbase64"
 	"github.com/gogf/gf/frame/g"
@@ -15,9 +19,6 @@ import (
 	"github.com/gogf/gf/text/gstr"
 	"github.com/gogf/gf/util/gconv"
 	"github.com/gogf/gf/util/gutil"
-	"regexp"
-	"runtime"
-	"strings"
 )
 
 // https://golang.google.cn/doc/install/source
@@ -270,7 +271,7 @@ func Run() {
 			// It's not necessary printing the complete command string.
 			cmdShow, _ := gregex.ReplaceString(`\s+(-ldflags ".+?")\s+`, " ", cmd)
 			mlog.Print(cmdShow)
-			if _, err := gproc.ShellExec(cmd); err != nil {
+			if err := gproc.ShellRun(cmd); err != nil {
 				mlog.Printf("failed to build, os:%s, arch:%s", system, arch)
 				mlog.Debugf("failed to build, os:%s, arch:%s, err:%+v", system, arch, err)
 			}


### PR DESCRIPTION
修改前，加了 `--debug` 也不显示具体的错误信息。
修改后错误信息正常显示。

修改前显示效果:
![image](https://user-images.githubusercontent.com/8181260/124755430-f3319e80-df5d-11eb-9c65-1c63d4da8472.png)

修改后显示效果:
![image](https://user-images.githubusercontent.com/8181260/124755200-a64dc800-df5d-11eb-85f5-b5370287a6b4.png)
