### PR TITLE
fix gfcli build error: [FATA] Error: exit status 128

### DIFF
--- a/internal/cmd/cmd_build.go
+++ b/internal/cmd/cmd_build.go
@@ -288,13 +288,13 @@ func (c cBuild) getGitCommit() string {
 	if gproc.SearchBinary("git") == "" {
 		return ""
 	}
-	s, err := gproc.ShellExec(`git log -1 --format="%cd %H" --date=format:"%Y-%m-%d %H:%M:%S"`)
+	s, err := gproc.ShellExec(`git log -1 --format=%cd_%H --date=format:%Y-%m-%d_%H:%M:%S`)
 	if err != nil {
 		mlog.Fatal(err)
 	}
 	if s != "" {
 		if !gstr.Contains(s, "fatal") {
-			return gstr.Trim(s)
+			return gstr.Trim(gstr.Replace(s, "_", " "))
 		}
 	}
 	return ""


### PR DESCRIPTION
执行git命令时 使用 _ 替代 空格
#140 